### PR TITLE
Ship es5 instead of es8

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Anyone that needs to use this package in a production environment has to transpile it since it ships in es2017. The current es2017 support looks like this:
![image](https://user-images.githubusercontent.com/1994028/57820990-bb46bc00-7743-11e9-94c3-ca59185e3bf2.png)

I guess es6 is a sensible target also, but es5 supports more environments and it doesn't seem like the library is using any special es6+ native implementations  (i.e Promise) that would cause the build to be bloated.

The JS ecosystem is still on es5 :(